### PR TITLE
Minor environment changes

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,45 +1,55 @@
 {
-    "name": "rub-kgi-latex-development",
-    "build": {
-        "dockerfile": "Dockerfile"
-    },
-    "containerEnv": {
-        "SHELL": "/bin/bash"
-    },
-    "customizations": {
-        "vscode": {
-            "settings": {
-                "latex-workshop.latex.tools": [
-                    {
-                      "name": "latexmk",
-                      "command": "latexmk",
-                      "args": [
-                        "-shell-escape",
-                        "-synctex=1",
-                        "-interaction=nonstopmode",
-                        "-file-line-error",
-                        "-pdf",
-                        "-outdir=%WORKSPACE_FOLDER%/out",
-                        "%DOC%"
-                      ],
-                      "env": {}
-                    }
-                  ],
-                  "latex-workshop.latex.recipes": [
-                    {
-                      "name": "latexmk",
-                      "tools": [
-                        "latexmk"
-                      ]
-                    }
-                  ]
-            },
-            "extensions": [
-                "GitHub.vscode-pull-request-github",
-                "Gruntfuggly.todo-tree",
-                "James-Yu.latex-workshop",
-                "mhutchie.git-graph"
+  "name": "rub-kgi-latex-development",
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "containerEnv": {
+    "SHELL": "/bin/bash"
+  },
+  "customizations": {
+    "vscode": {
+      "settings": {
+        // The number of spaces a tab is equal to. This setting is overridden
+        // based on the file contents when `editor.detectIndentation` is true.
+        "editor.tabSize": 2,
+        // Insert spaces when pressing Tab. This setting is overriden
+        // based on the file contents when `editor.detectIndentation` is true.
+        "editor.insertSpaces": true,
+        // When opening a file, `editor.tabSize` and `editor.insertSpaces`
+        // will be detected based on the file contents. Set to false to keep
+        // the values you've explicitly set, above.
+        "editor.detectIndentation": false,
+        "latex-workshop.latex.tools": [
+          {
+            "name": "latexmk",
+            "command": "latexmk",
+            "args": [
+              "-shell-escape",
+              "-synctex=1",
+              "-interaction=nonstopmode",
+              "-file-line-error",
+              "-pdf",
+              "-outdir=%WORKSPACE_FOLDER%/out",
+              "%DOC%"
+            ],
+            "env": {}
+          }
+        ],
+        "latex-workshop.latex.recipes": [
+          {
+            "name": "latexmk",
+            "tools": [
+              "latexmk"
             ]
-        }
+          }
+        ]
+      },
+      "extensions": [
+        "GitHub.vscode-pull-request-github",
+        "Gruntfuggly.todo-tree",
+        "James-Yu.latex-workshop",
+        "mhutchie.git-graph"
+      ]
     }
+  }
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -11,7 +11,7 @@
       "settings": {
         // The number of spaces a tab is equal to. This setting is overridden
         // based on the file contents when `editor.detectIndentation` is true.
-        "editor.tabSize": 2,
+        "editor.tabSize": 4,
         // Insert spaces when pressing Tab. This setting is overriden
         // based on the file contents when `editor.detectIndentation` is true.
         "editor.insertSpaces": true,


### PR DESCRIPTION
Makes minor environment changes by changing some vscode settings in the devcontainer.json file:
- sets tab size as 4 spaces
- enables inserting spaces instead of tabs
- disables auto detection of tab size