### PR TITLE
Issue #6 - Add GitHub workflow

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,4 +1,4 @@
-FROM texlive/texlive
+FROM registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
 
 # Install general tools
 RUN apt-get update && apt-get install --no-install-recommends -y \

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -38,6 +38,7 @@
                 ]
             },
             "extensions": [
+                "github.vscode-github-actions",
                 "GitHub.vscode-pull-request-github",
                 "Gruntfuggly.todo-tree",
                 "James-Yu.latex-workshop",

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,6 +29,7 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
+            rub-kgi/build/unpacked/rub-kgi.cls
             rub-kgi/build/distrib/**/*.zip
             rub-kgi/build/doc/*.pdf
             rub-kgi/build/unpacked/rub-kgi-example.tex

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -9,6 +9,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     container: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
+    permissions:
+      contents: write
     steps:
       # Check out the repository
       - name: Checkout repository

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -29,7 +29,6 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            rub-kgi/build/distrib/*.zip
-            rub-kgi/build/doc/rub-kgi.pdf
+            rub-kgi/build/distrib/**/*.zip
+            rub-kgi/build/doc/*.pdf
             rub-kgi/build/unpacked/rub-kgi-example.tex
-            rub-kgi/build/doc/rub-kgi-example.pdf

--- a/.github/workflows/deploy.yaml
+++ b/.github/workflows/deploy.yaml
@@ -1,0 +1,33 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    container: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
+    steps:
+      # Check out the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Run automated testing
+      # extract files from dtx
+      # build documentation
+      # and package a .zip for ctan
+      - name: Run l3build
+        run: l3build ctan -q -H
+        working-directory: ./rub-kgi
+
+      # Create a GitHub release
+      - name: Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: |
+            rub-kgi/build/distrib/*.zip
+            rub-kgi/build/doc/rub-kgi.pdf
+            rub-kgi/build/unpacked/rub-kgi-example.tex
+            rub-kgi/build/doc/rub-kgi-example.pdf

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -5,6 +5,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   l3build:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -1,0 +1,49 @@
+name: Automated testing and building
+
+on:
+  push:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  l3build:
+    runs-on: ubuntu-latest
+    container: registry.gitlab.com/islandoftex/images/texlive:TL2024-2024-05-19-full
+    steps:
+      # Check out the repository
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        
+      # Run automated testing
+      # extract files from dtx
+      # and build documentation
+      - name: Run l3build
+        run: l3build doc -q -H
+        working-directory: ./rub-kgi
+
+      # Upload artifacts
+      # Upload (main) documentation
+      - name: Upload documentation
+        uses: actions/upload-artifact@v4
+        with:
+          name: rub-kgi-manual.pdf
+          path: rub-kgi/rub-kgi.pdf
+      # Upload extracted class
+      - name: Upload class
+        uses: actions/upload-artifact@v4
+        with:
+          name: rub-kgi.cls
+          path: rub-kgi/build/unpacked/rub-kgi.cls
+      # Upload example
+      - name: Upload example tex file
+        uses: actions/upload-artifact@v4
+        with:
+          name: rub-kgi-example.tex
+          path: rub-kgi/build/unpacked/rub-kgi-example.tex
+      - name: Upload example pdf file
+        uses: actions/upload-artifact@v4
+        with:
+          name: rub-kgi-example.pdf
+          path: rub-kgi/rub-kgi-example.pdf
+            


### PR DESCRIPTION
This PR tracks the progress on Issue #6 to add a GitHub workflow.
So far we created a main workflow for automated testing and building which runs automatically on every push as well as every completed pr to the main branch. It uploads the unpacked class and example.tex as well as the manual pdf and the compiled example pdf files as artifacts.

What is still missing is a release or deploy workflow which should at least create a GitHub release after testing and later can easily be adapted to upload to CTAN.